### PR TITLE
Fix migration

### DIFF
--- a/migrations/0000_create_shells_table.sql
+++ b/migrations/0000_create_shells_table.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `shells` (
+CREATE TABLE IF NOT EXISTS `shells` (
 	`id` integer NOT NULL,
 	`distro` text NOT NULL,
 	`name` text NOT NULL,


### PR DESCRIPTION
The migration should attempt a create only if the table doesn’t already exist. 